### PR TITLE
Use sdl2 1.3 in tests and toys

### DIFF
--- a/caramia.cabal
+++ b/caramia.cabal
@@ -161,7 +161,7 @@ test-suite buffer
                       ,containers >=0.5.5 && <1.0
                       ,HUnit >=1.2.5.2 && <2.0
                       ,linear >=1.15 && <2.0
-                      ,sdl2 >= 2.0 && <3.0
+                      ,sdl2 >=1.3 && <2.0
                       ,test-framework >=0.8.1 && <1.0
                       ,test-framework-hunit >=0.3.0.1 && <1.0
   default-language:    Haskell2010
@@ -174,7 +174,7 @@ test-suite shader
   build-depends:       base, caramia
                       ,HUnit >=1.2.5.2 && <2.0
                       ,linear >=1.15 && <2.0
-                      ,sdl2 >= 2.0 && <3.0
+                      ,sdl2 >=1.3 && <2.0
                       ,test-framework >=0.8.1 && <1.0
                       ,test-framework-hunit >=0.3.0.1 && <1.0
   default-language:    Haskell2010
@@ -188,7 +188,7 @@ test-suite texture
                       ,containers >=0.5.5 && <1.0
                       ,HUnit >=1.2.5.2 && <2.0
                       ,linear >=1.15 && <2.0
-                      ,sdl2 >= 2.0 && <3.0
+                      ,sdl2 >=1.3 && <2.0
                       ,test-framework >=0.8.1 && <1.0
                       ,test-framework-hunit >=0.3.0.1 && <1.0
                       ,transformers >=0.3 && <1.0
@@ -214,7 +214,7 @@ executable smoke-test
   if flag(build-toys)
     build-depends:       base, caramia
                         ,linear >=1.18 && <2.0
-                        ,sdl2 ==1.2.*
+                        ,sdl2 >=1.3 && <2.0
                         ,text >=0.9 && <2.0
   else
     buildable:          False
@@ -227,7 +227,7 @@ executable memory-info
   hs-source-dirs:      demos/memory-info
   if flag(build-toys)
     build-depends:       base, caramia
-                        ,sdl2 ==1.2.*
+                        ,sdl2 >=1.3 && <2.0
   else
     buildable:           False
   default-language:    Haskell2010
@@ -238,8 +238,8 @@ executable gl-info
   ghc-options:         -Wall -fno-warn-name-shadowing -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:      demos/gl-info
   if flag(build-toys)
-    build-depends:       base
-                        ,sdl2 ==1.2.*
+    build-depends:       base, caramia
+                        ,sdl2 >=1.3 && <2.0
                         ,OpenGLRaw >=1.5
   else
     buildable:           False
@@ -251,7 +251,7 @@ executable query-objects
   hs-source-dirs:      demos/query-objects
   if flag(build-toys)
     build-depends:       base, caramia
-                        ,sdl2 ==1.2.*
+                        ,sdl2 >=1.3 && <2.0
                         ,text >=0.9 && <2.0
                         ,transformers >=0.3 && <1.0
                         ,vector >=0.10 && <1.0
@@ -265,7 +265,7 @@ executable textures
   hs-source-dirs:      demos/textures
   if flag(build-toys)
     build-depends:       base, caramia
-                        ,sdl2 ==1.2.*
+                        ,sdl2 >=1.3 && <2.0
   else
     buildable:           False
   default-language:    Haskell2010

--- a/demos/gl-info/Main.hs
+++ b/demos/gl-info/Main.hs
@@ -1,11 +1,11 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module Main ( main ) where
 
-import Prelude hiding (init )
 import Graphics.UI.SDL
 import Graphics.Rendering.OpenGL.Raw
 import Data.Bits
-import Control.Applicative
-import Control.Monad
+import Graphics.Caramia.Prelude hiding ( init )
 import Foreign.C.String
 import Foreign.Storable
 import Foreign.Marshal.Alloc
@@ -15,14 +15,14 @@ main :: IO ()
 main =
     withCString "gl-test" $ \cstr -> do
         let errCheck s x = unless (x == 0) $ error s
-        errCheck "Can't initialize SDL" =<< init initFlagVideo
-        errCheck "Can't set major version" =<< glSetAttribute glAttrContextMajorVersion 3
-        errCheck "Can't set minor version" =<< glSetAttribute glAttrContextMinorVersion 3
-        errCheck "Can't set profile mask" =<< glSetAttribute glAttrContextProfileMask glProfileCore
-        window <- createWindow cstr windowPosUndefined windowPosUndefined
+        errCheck "Can't initialize SDL" =<< init SDL_INIT_VIDEO
+        errCheck "Can't set major version" =<< glSetAttribute SDL_GL_CONTEXT_MAJOR_VERSION 3
+        errCheck "Can't set minor version" =<< glSetAttribute SDL_GL_CONTEXT_MINOR_VERSION 3
+        errCheck "Can't set profile mask" =<< glSetAttribute SDL_GL_CONTEXT_PROFILE_MASK SDL_GL_CONTEXT_PROFILE_CORE
+        window <- createWindow cstr SDL_WINDOWPOS_UNDEFINED SDL_WINDOWPOS_UNDEFINED
                                     500 500
-                                    (windowFlagOpenGL .|.
-                                     windowFlagShown)
+                                    (SDL_WINDOW_OPENGL .|.
+                                     SDL_WINDOW_SHOWN)
         c <- glCreateContext window
         _ <- glMakeCurrent window c
         (major1, minor1) <- alloca $ \major_ptr -> alloca $ \minor_ptr -> do

--- a/demos/memory-info/Main.hs
+++ b/demos/memory-info/Main.hs
@@ -10,15 +10,15 @@ import Prelude hiding ( init )
 main :: IO ()
 main = 
     withCString "smoke-test" $ \cstr -> do
-        void $ init initFlagVideo
-        _ <- glSetAttribute glAttrContextMajorVersion 3
-        _ <- glSetAttribute glAttrContextMinorVersion 3
-        _ <- glSetAttribute glAttrContextProfileMask glProfileCore
-        _ <- glSetAttribute glAttrContextFlags glContextFlagDebug
-        window <- createWindow cstr windowPosUndefined windowPosUndefined
+        void $ init SDL_INIT_VIDEO
+        _ <- glSetAttribute SDL_GL_CONTEXT_MAJOR_VERSION 3
+        _ <- glSetAttribute SDL_GL_CONTEXT_MINOR_VERSION 3
+        _ <- glSetAttribute SDL_GL_CONTEXT_PROFILE_MASK SDL_GL_CONTEXT_PROFILE_CORE
+        _ <- glSetAttribute  SDL_GL_CONTEXT_FLAGS SDL_GL_CONTEXT_DEBUG_FLAG
+        window <- createWindow cstr SDL_WINDOWPOS_UNDEFINED SDL_WINDOWPOS_UNDEFINED
                                     500 500
-                                    (windowFlagOpenGL .|.
-                                     windowFlagShown)
+                                    (SDL_WINDOW_OPENGL .|.
+                                     SDL_WINDOW_SHOWN)
         _ <- glCreateContext window
         giveContext $ do
             putStrLn "Attempting to retrieve GPU memory information..."

--- a/demos/query-objects/Main.hs
+++ b/demos/query-objects/Main.hs
@@ -19,15 +19,14 @@ import Graphics.UI.SDL
 main :: IO ()
 main =
     withCString "query-objects" $ \cstr -> do
-        void $ init initFlagVideo
-        _ <- glSetAttribute glAttrContextMajorVersion 3
-        _ <- glSetAttribute glAttrContextMinorVersion 3
-        _ <- glSetAttribute glAttrContextProfileMask glProfileCore
-        _ <- glSetAttribute glAttrContextFlags glContextFlagDebug
-        window <- createWindow cstr windowPosUndefined windowPosUndefined
+        _ <- glSetAttribute SDL_GL_CONTEXT_MAJOR_VERSION 3
+        _ <- glSetAttribute SDL_GL_CONTEXT_MINOR_VERSION 3
+        _ <- glSetAttribute SDL_GL_CONTEXT_PROFILE_MASK SDL_GL_CONTEXT_PROFILE_CORE
+        _ <- glSetAttribute  SDL_GL_CONTEXT_FLAGS SDL_GL_CONTEXT_DEBUG_FLAG
+        window <- createWindow cstr SDL_WINDOWPOS_UNDEFINED SDL_WINDOWPOS_UNDEFINED
                                     500 500
-                                    (windowFlagOpenGL .|.
-                                     windowFlagShown)
+                                    (SDL_WINDOW_OPENGL .|.
+                                     SDL_WINDOW_SHOWN)
         _ <- glCreateContext window
         giveContext $ do
             color_program <- newPipelineVF passThroughVertex2DShader

--- a/demos/smoke-test/Main.hs
+++ b/demos/smoke-test/Main.hs
@@ -10,7 +10,6 @@ import Foreign.C.Types
 import Graphics.Caramia.Prelude hiding ( init )
 import Graphics.Caramia
 import Graphics.UI.SDL
-import qualified Graphics.UI.SDL as SDL
 import Linear.Matrix
 import System.Mem
 
@@ -26,22 +25,21 @@ main = do
     putStrLn "Press enter to start the smoke test."
     _ <- getLine
     putStrLn "Running the smoke test..."
-    bracket_ (SDL.init initFlagVideo)
+    bracket_ (init SDL_INIT_VIDEO)
              quit
              program
 
 program :: IO ()
 program =
     withCString "smoke-test" $ \cstr -> do
-        void $ init initFlagVideo
-        _ <- glSetAttribute glAttrContextMajorVersion 3
-        _ <- glSetAttribute glAttrContextMinorVersion 3
-        _ <- glSetAttribute glAttrContextProfileMask glProfileCore
-        _ <- glSetAttribute glAttrContextFlags glContextFlagDebug
-        window <- createWindow cstr windowPosUndefined windowPosUndefined
+        _ <- glSetAttribute SDL_GL_CONTEXT_MAJOR_VERSION 3
+        _ <- glSetAttribute SDL_GL_CONTEXT_MINOR_VERSION 3
+        _ <- glSetAttribute SDL_GL_CONTEXT_PROFILE_MASK SDL_GL_CONTEXT_PROFILE_CORE
+        _ <- glSetAttribute  SDL_GL_CONTEXT_FLAGS SDL_GL_CONTEXT_DEBUG_FLAG
+        window <- createWindow cstr SDL_WINDOWPOS_UNDEFINED SDL_WINDOWPOS_UNDEFINED
                                     500 500
-                                    (windowFlagOpenGL .|.
-                                     windowFlagShown)
+                                    (SDL_WINDOW_OPENGL .|.
+                                     SDL_WINDOW_SHOWN)
         _ <- glCreateContext window
         giveContext $ do
             -- Make some buffers.

--- a/demos/textures/Main.hs
+++ b/demos/textures/Main.hs
@@ -11,15 +11,14 @@ import Foreign.C.String
 main :: IO ()
 main = 
     withCString "smoke-test" $ \cstr -> do
-        void $ init initFlagVideo
-        _ <- glSetAttribute glAttrContextMajorVersion 3
-        _ <- glSetAttribute glAttrContextMinorVersion 3
-        _ <- glSetAttribute glAttrContextProfileMask glProfileCore
-        _ <- glSetAttribute glAttrContextFlags glContextFlagDebug
-        window <- createWindow cstr windowPosUndefined windowPosUndefined
+        _ <- glSetAttribute SDL_GL_CONTEXT_MAJOR_VERSION 3
+        _ <- glSetAttribute SDL_GL_CONTEXT_MINOR_VERSION 3
+        _ <- glSetAttribute SDL_GL_CONTEXT_PROFILE_MASK SDL_GL_CONTEXT_PROFILE_CORE
+        _ <- glSetAttribute  SDL_GL_CONTEXT_FLAGS SDL_GL_CONTEXT_DEBUG_FLAG
+        window <- createWindow cstr SDL_WINDOWPOS_UNDEFINED SDL_WINDOWPOS_UNDEFINED
                                     500 500
-                                    (windowFlagOpenGL .|.
-                                     windowFlagShown)
+                                    (SDL_WINDOW_OPENGL .|.
+                                     SDL_WINDOW_SHOWN)
         _ <- glCreateContext window
         giveContext $ do
             putStrLn "Attempting to create all sorts of textures..."

--- a/tests/buffer/Main.hs
+++ b/tests/buffer/Main.hs
@@ -4,6 +4,8 @@
 
 module Main ( main ) where
 
+import Foreign.C.String
+import Data.Bits
 import Control.Concurrent
 import Control.Exception
 import qualified Data.Set as S
@@ -12,10 +14,8 @@ import Foreign.Marshal.Alloc
 import Foreign.Ptr
 import Foreign.Storable
 import Graphics.Caramia
-import Graphics.Caramia.Prelude
-import Linear.V2
-import SDL
-import System.IO.Unsafe ( unsafePerformIO )
+import Graphics.Caramia.Prelude hiding ( init )
+import Graphics.UI.SDL
 import Test.Framework
 import Test.Framework.Providers.HUnit
 import Test.HUnit hiding ( Test )
@@ -23,20 +23,17 @@ import Test.HUnit hiding ( Test )
 foreign import ccall unsafe "memset" c_memset
     :: Ptr a -> CInt -> CSize -> IO (Ptr b)
 
-sdlLock :: MVar ()
-sdlLock = unsafePerformIO $ newMVar ()
-{-# NOINLINE sdlLock #-}
-
 setup :: IO a -> IO a
-setup action = runInBoundThread $ withMVar sdlLock $ \_ -> do
-    initialize [InitEverything]
-    let glconfig = defaultOpenGL {
-                    glProfile = Core Normal 3 3
-                    }
-    w <- createWindow "buffer" defaultWindow {
-            windowOpenGL = Just glconfig
-        , windowSize = V2 1500 1000
-        }
+setup action = runInBoundThread $ withCString "buffer" $ \cstr -> do
+    _ <- init SDL_INIT_VIDEO
+    _ <- glSetAttribute SDL_GL_CONTEXT_MAJOR_VERSION 3
+    _ <- glSetAttribute SDL_GL_CONTEXT_MINOR_VERSION 3
+    _ <- glSetAttribute SDL_GL_CONTEXT_PROFILE_MASK SDL_GL_CONTEXT_PROFILE_CORE
+    _ <- glSetAttribute SDL_GL_CONTEXT_FLAGS SDL_GL_CONTEXT_DEBUG_FLAG
+    w <- createWindow cstr SDL_WINDOWPOS_UNDEFINED SDL_WINDOWPOS_UNDEFINED
+                           1500 1000
+                           (SDL_WINDOW_OPENGL .|.
+                            SDL_WINDOW_SHOWN)
     ctx <- glCreateContext w
     finally (giveContext action) $ do
         glDeleteContext ctx

--- a/tests/shader/Main.hs
+++ b/tests/shader/Main.hs
@@ -4,30 +4,27 @@
 
 module Main ( main ) where
 
+import Foreign.C.String
+import Data.Bits
 import Control.Concurrent
 import Control.Exception
-import Linear.V2
 import Graphics.Caramia
-import Graphics.Caramia.Prelude
-import SDL
-import System.IO.Unsafe ( unsafePerformIO )
+import Graphics.Caramia.Prelude hiding ( init )
+import Graphics.UI.SDL
 import Test.Framework
 import Test.Framework.Providers.HUnit
 
-sdlLock :: MVar ()
-sdlLock = unsafePerformIO $ newMVar ()
-{-# NOINLINE sdlLock #-}
-
 setup :: IO a -> IO a
-setup action = runInBoundThread $ withMVar sdlLock $ \_ -> do
-    initialize [InitEverything]
-    let glconfig = defaultOpenGL {
-                    glProfile = Core Normal 3 3
-                    }
-    w <- createWindow "buffer" defaultWindow {
-            windowOpenGL = Just glconfig
-        , windowSize = V2 1500 1000
-        }
+setup action = runInBoundThread $ withCString "shader" $ \cstr -> do
+    _ <- init SDL_INIT_VIDEO
+    _ <- glSetAttribute SDL_GL_CONTEXT_MAJOR_VERSION 3
+    _ <- glSetAttribute SDL_GL_CONTEXT_MINOR_VERSION 3
+    _ <- glSetAttribute SDL_GL_CONTEXT_PROFILE_MASK SDL_GL_CONTEXT_PROFILE_CORE
+    _ <- glSetAttribute SDL_GL_CONTEXT_FLAGS SDL_GL_CONTEXT_DEBUG_FLAG
+    w <- createWindow cstr SDL_WINDOWPOS_UNDEFINED SDL_WINDOWPOS_UNDEFINED
+                           1500 1000
+                           (SDL_WINDOW_OPENGL .|.
+                            SDL_WINDOW_SHOWN)
     ctx <- glCreateContext w
     finally (giveContext action) $ do
         glDeleteContext ctx


### PR DESCRIPTION
This unifies SDL2 version in both toys and tests to be 1.3. It dowgrades from `new-api` branch in tests but this allows people to run tests without problems when building from Hackage. PR because I'm not sure this is desired.
